### PR TITLE
Ignore comments marks to not be seen as a whole delete/insertion change when doing diff.

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -2,13 +2,24 @@ const IGNORED_ATTRS = {
   blockId: true,
 }
 
+const IGNORED_MARKS = {
+  comment: true,
+}
+
 const getMarksString = (node) => {
   let marksString = ''
   let keys = Object.keys(node.marks)
   keys.sort()
   for (let i = 0; i < keys.length; i++) {
-    marksString += `${keys[i]}:${node.marks[keys[i]]}`
+    const mark = node.marks[keys[i]]
+
+    if (IGNORED_MARKS[mark.type.name]) {
+      continue
+    }
+
+    marksString += `${keys[i]}:${mark.type.name}`
   }
+
   return marksString
 }
 


### PR DESCRIPTION
Linear ticket.
https://linear.app/almanac/issue/OS-850/leaving-a-comment-on-a-unauthd-branch-with-tracked-changes

**Changes**

- This skips the comments mark to be added to the markString. Making comments to not be seen as change.

**Notes for reviewers**

It had a hard time testing the modification to the test this change.
The `comment` mark is not available in the basic schema, so I tried to use prose-core's schema to generate the helpers.

Although the setup seems to work fine, almost all the test cases are failing when using the new schema.
Some are just different ranges that can just be change in the test expectation, but others are just complete wrong values like retuning not diff when it should be one.

Maybe we can take a look at this in the future in a pair session or whenever I got more familiar with this.

** Demo **
https://user-images.githubusercontent.com/999204/139136261-a4f8a4bf-1a52-4715-b276-70998613c401.mov

## Checklist

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
