### PR TITLE
Bump package.json version to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "prosemirror-changeset",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.2.0",
+      "name": "prosemirror-changeset",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "prosemirror-transform": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prosemirror-changeset",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Distills a series of editing steps into deleted and added ranges",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
This was a missing change from https://github.com/almanaclabs/prosemirror-changeset/pull/3 as  I thought that the release command would update the package.json.