### PR TITLE
Add support for fenced nodes

### DIFF
--- a/test/test-diff.js
+++ b/test/test-diff.js
@@ -67,4 +67,19 @@ describe('computeDiff', () => {
   })
 
   it('can handle ambiguous diffs', () => test(doc(p('abcbcd')), doc(p('abcd')), [4, 6, 4, 4]))
+
+  it('can handle prepended heading with overlapping content', () =>
+    test(
+      doc(h1('abcd')),
+      doc(h1('abef'), h1('abcd')),
+      [0,0,0,6]
+    ))
+
+  it('can handle headings with overlapping content', () =>
+    test(
+      doc(h1('abcd'), h2('abcd')),
+      doc(h1('abef'), h1('abcd'), h2('abef'), h2('abcd')),
+      [0,0,0,6],
+      [6, 6, 12, 18]
+    ))
 })


### PR DESCRIPTION
**Changes**

This PR introduces "fenced nodes", which are nodes that should be looked at and matched between A and B when computing the diff before the algorithm computes the diff at char level. This is a trivial solution to the scenario where the algorithm generates a correct but unintuitive diff for a node that is prepended to another node that starts with the same content:

```
Doc A: 
# February 10th, 2022

Doc B
# February 17th, 2022
# February 10th, 2022
```

In this case, we want to try and match entire nodes first, and then proceed to character-level diffing. 

Things to improve:
- "fenced node" naming: I don't think it really explains what it represents, it'd be great to find a better name
- fenced nodes should be configurable at runtime, not baked into the library. For now, this was to get the proof of concept off the ground
- Add more tests

## Checklist

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
