### PR TITLE
Bump to 2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prosemirror-changeset",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Distills a series of editing steps into deleted and added ranges",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
**Changes**

- `2.4.4` publishes the built files under `dist` which is referenced from `package.json`

**Notes for reviewers**

- How can someone test this?

## Checklist

### Security

- [ ] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
